### PR TITLE
docs: add Moodle integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,53 @@
-# Website
+## Educado Technical Documentation
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+This repository contains the documentation site for the **Educado** project. It is built with [Docusaurus](https://docusaurus.io/) and provides guidelines for all teams contributing to the mobile learning platform.
 
-## Installation
-
-```bash
-yarn
-```
-
-## Local Development
+### Installation
 
 ```bash
-yarn start
+npm install
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
+### Local Development
 
 ```bash
-yarn build
+npm start
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command starts a local development server and opens a browser window. Most changes are reflected live without restarting the server.
 
-## Deployment
+### Build
+
+```bash
+npm run build
+```
+
+Generates static content in the `build` directory for deployment.
+
+### Documentation Structure
+
+The docs are organised into several sections:
+
+- **Project Overview** – background and project goals
+- **Development Workflow** – task management and GitHub practices
+- **Coding Conventions** – naming and style guidelines
+- **Frontend Development** – React Native standards
+- **Backend Development** – Node.js/Express guidelines
+- **Moodle Integration** – using Moodle as the content platform
+
+### Deployment
 
 Using SSH:
 
 ```bash
-USE_SSH=true yarn deploy
+USE_SSH=true npm run deploy
 ```
 
 Not using SSH:
 
 ```bash
-GIT_USER=<Your GitHub username> yarn deploy
+GIT_USER=<Your GitHub username> npm run deploy
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+If you are using GitHub pages for hosting, this command builds the website and pushes to the `gh-pages` branch.
+

--- a/docs/moodle-integration.md
+++ b/docs/moodle-integration.md
@@ -1,0 +1,28 @@
+# Moodle Integration
+
+## Overview
+
+Moodle will host the educational content for Educado. The React Native app consumes Moodle data through its web services API, allowing content creators to manage courses separately from the mobile client.
+
+## Setup
+
+- Maintain a Moodle instance operated by the content team.
+- Enable the [Moodle web services API](https://docs.moodle.org/dev/Using_web_services).
+- Create a dedicated service user and generate tokens for API access.
+
+## Accessing Content
+
+1. The app authenticates with Moodle using the service token.
+2. Course data is fetched through REST endpoints such as `/webservice/rest/server.php`.
+3. Media assets (videos, images) should be stored in Moodle and referenced by URL.
+
+## Synchronisation Strategy
+
+- Cache downloaded lessons on the device for offline use.
+- Use lightweight requests to respect limited bandwidth and hardware constraints.
+- Schedule background updates when connectivity is available.
+
+## Next Steps
+
+Document available endpoints and payloads once the Moodle instance is configured. Include example requests for enrolling users and fetching course modules.
+

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -42,10 +42,17 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Backend Development', 
+      label: 'Backend Development',
       items: [
         'backend/index',
         'backend/file-structure',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Moodle Integration',
+      items: [
+        'moodle-integration',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- document Moodle setup and content sync strategy
- highlight site structure and deployment commands in README
- expose new section in sidebar for easier navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7305e6c58832fb3e3aabedb2fa53c